### PR TITLE
Implement navigation from stub to the schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 ## Unreleased
 
+### Added
+- Line markers to navigate from stub to the corresponding gRPC service/method
+- Find gRPC method calls through coroutine-based stubs
+
 ## 1.6.30 - 2022-12-01
 
 ### Changed

--- a/src/main/kotlin/io/kanro/idea/plugin/protobuf/java/JavaFindUsageFactory.kt
+++ b/src/main/kotlin/io/kanro/idea/plugin/protobuf/java/JavaFindUsageFactory.kt
@@ -42,7 +42,8 @@ class JavaFindUsageFactory : FindUsagesHandlerFactory() {
                         element.toImplBaseClass(),
                         element.toStubClass(),
                         element.toBlockingStubClass(),
-                        element.toFutureStubClass()
+                        element.toFutureStubClass(),
+                        element.toCoroutineStubClass(),
                     ).toTypedArray()
                 )
             }
@@ -56,7 +57,8 @@ class JavaFindUsageFactory : FindUsagesHandlerFactory() {
                         element.toImplBaseMethod(),
                         element.toStubMethod(),
                         element.toBlockingStubMethod(),
-                        element.toFutureStubMethod()
+                        element.toFutureStubMethod(),
+                        element.toCoroutineStubMethod(),
                     ).toTypedArray()
                 )
             }

--- a/src/main/kotlin/io/kanro/idea/plugin/protobuf/java/JavaIndexProvider.kt
+++ b/src/main/kotlin/io/kanro/idea/plugin/protobuf/java/JavaIndexProvider.kt
@@ -10,17 +10,43 @@ class JavaIndexProvider : ProtobufIndexProvider {
     override fun buildIndex(stub: ProtobufStub<*>, sink: IndexSink) {
         when (stub) {
             is ProtobufServiceStub -> {
+                // impls
                 sink.occurrence(JavaNameIndex.key, stub.fullImplBaseName().toString())
                 sink.occurrence(JavaNameIndex.key, stub.fullCoroutineImplBaseName().toString())
+                // stubs
+                sink.occurrence(JavaNameIndex.key, stub.fullStubName().toString())
+                sink.occurrence(JavaNameIndex.key, stub.fullBlockingStubName().toString())
+                sink.occurrence(JavaNameIndex.key, stub.fullFutureStubName().toString())
+                sink.occurrence(JavaNameIndex.key, stub.fullCoroutineStubName().toString())
             }
             is ProtobufRpcStub -> {
+                val methodName = stub.methodName()
+
+                // impls
                 sink.occurrence(
                     JavaNameIndex.key,
-                    stub.owner()?.fullImplBaseName()?.append(stub.methodName()).toString()
+                    stub.owner()?.fullImplBaseName()?.append(methodName).toString()
                 )
                 sink.occurrence(
                     JavaNameIndex.key,
-                    stub.owner()?.fullCoroutineImplBaseName()?.append(stub.methodName()).toString()
+                    stub.owner()?.fullCoroutineImplBaseName()?.append(methodName).toString()
+                )
+                // stubs
+                sink.occurrence(
+                    JavaNameIndex.key,
+                    stub.owner()?.fullStubName()?.append(methodName).toString()
+                )
+                sink.occurrence(
+                    JavaNameIndex.key,
+                    stub.owner()?.fullBlockingStubName()?.append(methodName).toString()
+                )
+                sink.occurrence(
+                    JavaNameIndex.key,
+                    stub.owner()?.fullFutureStubName()?.append(methodName).toString()
+                )
+                sink.occurrence(
+                    JavaNameIndex.key,
+                    stub.owner()?.fullCoroutineStubName()?.append(methodName).toString()
                 )
             }
         }


### PR DESCRIPTION
Closes #193 
This PR adds line markers, similar to the implementation of gRPC service and method, to the generated stubs (of all kinds), see attached screenshots
<img width="596" alt="изображение" src="https://github.com/devkanro/intellij-protobuf-plugin/assets/14140464/65353f20-73bf-4eeb-8b74-a1fb12e8c07f">
<img width="574" alt="изображение" src="https://github.com/devkanro/intellij-protobuf-plugin/assets/14140464/21d67bc7-ed70-402b-8815-f66c9ab04a42">
<img width="761" alt="изображение" src="https://github.com/devkanro/intellij-protobuf-plugin/assets/14140464/f5e8aca0-f469-4dc9-87f5-ddc05387217c">
<img width="597" alt="изображение" src="https://github.com/devkanro/intellij-protobuf-plugin/assets/14140464/785be1db-9897-441e-bc8f-a05bb59b30e3">

In addition, it adds gRPC method calls, made using coroutine-based stubs, to the usages of the corresponding gRPC methods, so, it is now possible to navigate from gRPC schema to the client-side gRPC call made using coroutine-based stub.