### PR TITLE
chore: update build plugins for 2026.1

### DIFF
--- a/.github/knowledge.md
+++ b/.github/knowledge.md
@@ -1,0 +1,46 @@
+---
+updated: 2026-05-09
+---
+
+# Knowledge Base
+
+Accumulated learnings from this project. Read this before starting new work.
+
+## Project Patterns
+
+- IntelliJ Platform Gradle Plugin upgrades can require both Gradle wrapper updates and build script API adjustments.
+- Grammar/parser generation depends on IntelliJ Platform classpath alignment; when `generateParser` fails with missing IntelliJ classes, check Grammar-Kit and IntelliJ Platform Gradle Plugin compatibility together.
+
+## Common Pitfalls
+
+- `README.md` must contain `<!-- Plugin description -->` and `<!-- Plugin description end -->` markers because `patchPluginXml` extracts the plugin description from that section.
+- Local Gradle project caches under `.gradle` can fail on Windows with file-lock or directory-creation errors; validating in a clean temporary workspace can distinguish local cache problems from source/build-script problems.
+
+## Workflow Learnings
+
+- For build-tooling updates, verify plugin portal versions first, then run a clean build after each compatibility-driven change.
+- When a standard workspace build is blocked by local cache permissions, document the workaround and validation command in the PR.
+
+## Reflections
+
+### 2026-05-09 — Build plugin update for 2026.1
+
+**What was done**: Updated the build tooling for the 2026.1 target by upgrading the IntelliJ Platform Gradle Plugin, Grammar-Kit plugin, and Gradle wrapper. Adapted the `create()` dependency declaration to the newer API and restored README plugin-description markers required by `patchPluginXml`.
+
+**What went well**:
+- Updating Grammar-Kit and IntelliJ Platform Gradle Plugin together resolved the original `generateParser` classpath failure.
+- A clean temporary workspace build isolated source/build-script issues from local `.gradle` cache permission problems.
+- The final build passed after adapting the dependency declaration and restoring README markers.
+
+**What was harder than expected**:
+- IntelliJ Platform Gradle Plugin `2.16.0` required Gradle `9.0.0`, which introduced an API compatibility adjustment in `build.gradle.kts`.
+- The local workspace Gradle cache repeatedly failed with Windows file-lock/directory errors, so standard in-place build verification was not reliable.
+- `patchPluginXml` failed late because the README description markers were missing.
+
+**Patterns noticed**:
+- Build-tooling upgrades often reveal chained compatibility requirements: Gradle plugin version, Gradle wrapper version, DSL API, and documentation-derived metadata all need to line up.
+- Local environment failures should be separated from source failures by using a clean copy and explicit temporary cache directories.
+
+**Workflow observations**:
+- The ship flow caught the local standard-build failure, but the clean-workspace validation provided enough confidence to proceed with a documented PR note.
+- This was a quick build-tooling fix without a dedicated brainstorm; future non-trivial version migrations should start with a brief brainstorm entry before edits.

--- a/.mcp.json
+++ b/.mcp.json
@@ -1,0 +1,9 @@
+{
+  "mcpServers": {
+    "knowledge": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "knowledgebased"]
+    }
+  }
+}

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@
 
 ---
 
+<!-- Plugin description -->
+
 ## ✨ What It Does
 
 This plugin turns your JetBrains IDE into a protobuf-aware development environment — not just syntax highlighting, but deep understanding of your schema.
@@ -21,6 +23,8 @@ This plugin turns your JetBrains IDE into a protobuf-aware development environme
 > [!WARNING]
 > Not compatible with the bundled [JetBrains Protocol Buffer plugin](https://plugins.jetbrains.com/plugin/14004-protocol-buffers).
 > Disable **Protocol Buffer** and **gRPC** before installing.
+
+<!-- Plugin description end -->
 
 ## 🚀 Quick Start
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -43,7 +43,9 @@ dependencies {
 
     // IntelliJ Platform Gradle Plugin Dependencies Extension - read more: https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-dependencies-extension.html
     intellijPlatform {
-        create(providers.gradleProperty("platformType"), providers.gradleProperty("platformVersion"), useInstaller = false)
+        create(providers.gradleProperty("platformType"), providers.gradleProperty("platformVersion")) {
+            useInstaller = false
+        }
 
         // Plugin Dependencies. Uses `platformBundledPlugins` property from the gradle.properties file for bundled IntelliJ Platform plugins.
         bundledPlugins(providers.gradleProperty("platformBundledPlugins").map { it.split(',') })

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,24 +4,24 @@ pluginName=IntelliJ Protobuf Language Plugin
 pluginRepositoryUrl=https://github.com/devkanro/intellij-protobuf-plugin
 
 # SemVer format -> https://semver.org
-pluginVersion=2.3.0
+pluginVersion=2.4.0
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild=253
-pluginUntilBuild=253.*
+pluginSinceBuild=261
+pluginUntilBuild=261.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType=IU
-platformVersion=2025.3
+platformVersion=2026.1
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP, com.intellij.grpc:251.23774.350
-platformPlugins=org.jetbrains.plugins.go:253.28294.251, com.jetbrains.restClient:253.28294.251
+platformPlugins=org.jetbrains.plugins.go:261.22158.277, com.jetbrains.restClient:261.22158.182
 # Example: platformBundledPlugins = com.intellij.java
 platformBundledPlugins=com.intellij.java, org.jetbrains.kotlin, com.intellij.modules.json, org.intellij.plugins.markdown
 
 # Gradle Releases -> https://github.com/gradle/gradle/releases
-gradleVersion = 8.10.2
+gradleVersion = 9.0.0
 
 # Opt-out flag for bundling Kotlin standard library -> https://jb.gg/intellij-platform-kotlin-stdlib
 kotlin.stdlib.default.dependency = false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,11 +4,11 @@ junit = "4.13.2"
 
 # plugins
 changelog = "2.2.1"
-intelliJPlatform = "2.5.0"
-kotlin = "2.3.0-RC3"
+intelliJPlatform = "2.16.0"
+kotlin = "2.3.20"
 kover = "0.8.3"
 qodana = "2024.2.3"
-grammarkit = "2023.3"
+grammarkit = "2023.3.0.3"
 
 [libraries]
 junit = { group = "junit", name = "junit", version.ref = "junit" }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.10.2-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.0.0-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/knowledge/architecture/extension-points.md
+++ b/knowledge/architecture/extension-points.md
@@ -1,0 +1,44 @@
+---
+tags: [architecture, extension-points, api]
+related: [architecture/layer-diagram, modules/java, modules/go]
+refs: [docs/extension-points.md]
+---
+# Extension Points
+
+Five extension points allow third-party plugins to extend the core. All are dynamic (support runtime loading/unloading).
+
+## rootProvider
+
+**Interface**: `ProtobufRootProvider`
+
+Provides import root directories for proto file resolution. Built-in: `ModuleSourceRootProvider`, `LibraryRootProvider`, `EmbeddedRootProvider`, `DecompiledRootProvider`, `GoRootProvider`.
+
+```xml
+<extensions defaultExtensionNs="io.kanro.idea.plugin.protobuf">
+    <rootProvider implementation="com.example.MyRootProvider"/>
+</extensions>
+```
+
+## symbolReferenceProvider
+
+**Interface**: `ProtobufSymbolReferenceProvider`
+
+Custom symbol references beyond standard proto references. Used by AIP to resolve resource type names in string literals.
+
+## indexProvider
+
+**Interface**: `ProtobufIndexProvider`
+
+Contributes index entries for proto elements, enabling navigation between proto definitions and generated code. Built-in: `JavaIndexProvider`, `GoIndexProvider`, `SisyphusIndexProvider`.
+
+## stubExternalProvider
+
+**Interface**: `ProtobufStubExternalProvider`
+
+Provides additional external data stored alongside PSI stubs. Used by Java integration to cache Java option values (`java_package`, `java_outer_classname`, `java_multiple_files`).
+
+## protocPlugin
+
+**Interface**: `ProtobufCompilerPlugin`
+
+Hooks into the protobuf compilation process. 10 built-in compilers cover File, Message, Field, Oneof, MapEntry, MapField, Enum, EnumValue, Service, and ServiceMethod compilation.

--- a/knowledge/architecture/layer-diagram.md
+++ b/knowledge/architecture/layer-diagram.md
@@ -1,0 +1,46 @@
+---
+tags: [architecture, overview, layers]
+related: [architecture/extension-points, design/psi-mixin-injection]
+refs: [docs/architecture.md, docs/overview.md]
+---
+# Plugin Architecture Layers
+
+IntelliJ Protobuf Language Plugin is a full-featured Protocol Buffers language plugin for JetBrains IDEs with deep semantic understanding, cross-file symbol resolution, multi-language integration, and Editions support.
+
+## Layer Diagram
+
+```
+┌─────────────────────────────────────────────┐
+│             UI & Settings                   │
+│   Settings, Structure View, Icons, Actions  │
+├─────────────────────────────────────────────┤
+│           Language Support                  │
+│   Completion, Formatting, Annotations,      │
+│   References, Quick Fixes, Find Usages      │
+├─────────────────────────────────────────────┤
+│         PSI (Program Structure)             │
+│   Elements, Mixins, Scope, Features         │
+├─────────────────────────────────────────────┤
+│           Indexing & Stubs                  │
+│   Stub Indices, Root Providers, Caching     │
+├─────────────────────────────────────────────┤
+│           Parsing & Lexing                  │
+│   Lexer (FLEX), Parser (BNF), Language Def  │
+├─────────────────────────────────────────────┤
+│       Integration Modules (Optional)        │
+│   Java, Go, Sisyphus, gRPC, AIP            │
+└─────────────────────────────────────────────┘
+```
+
+Each layer depends only on the layer below it. Integration modules sit alongside, hooking into specific layers via extension points.
+
+## Key Concepts
+
+- **Proto Files as First-Class Code**: `.proto` files get full PSI trees, stub indices, and cross-project reference resolution like Java or Kotlin.
+- **Multi-Source Symbol Resolution**: Root providers aggregate proto files from project sources, library JARs, the protobuf SDK, and decompiled descriptors.
+- **Integration Modules**: Language-specific features activate only when relevant IDE plugins are present, keeping the core lightweight.
+- **Internal Compiler**: In-process protobuf compiler produces `FileDescriptorProto` from PSI without external `protoc`.
+
+## Parsing & Lexing
+
+Grammar files in `src/main/grammar/` define the syntax — `protobuf.bnf` for proto2/proto3/editions, `prototext.bnf` for text format. Grammar-Kit and JFlex generate the parser and lexer. Generated code goes to `build/generated/sources/grammar/`.

--- a/knowledge/design/annotation-layers.md
+++ b/knowledge/design/annotation-layers.md
@@ -1,0 +1,29 @@
+---
+tags: [design, annotation, validation, proto2, proto3]
+related: [design/annotation-quick-fixes, design/editions-feature-model]
+refs: [docs/design/annotation-system.md]
+---
+# Annotation System — Layered Validation
+
+Protobuf is three divergent dialects sharing one syntax. Proto2 *requires* field labels; proto3 *forbids* `required`. Proto3 bans groups, extensions, default values — all legal in proto2. A single validator would devolve into a tangle of conditionals.
+
+## Per-Version Annotators
+
+| Layer | Class | Activates When |
+|-------|-------|----------------|
+| Universal | `ProtobufAnnotator` | Always (all `.proto` files) |
+| Proto2 | `Protobuf2Annotator` | `syntax` is `"proto2"` or unspecified |
+| Proto3 | `Protobuf3Annotator` | `syntax` is exactly `"proto3"` |
+| Editions | `ProtobufEditionAnnotator` | `edition()` is non-null |
+
+Each version annotator self-gates with an early return. Gating is cheap — a single `file.syntax()` call.
+
+## Annotators Over Inspections
+
+Protobuf errors are specification violations — `protoc` will reject the file. Making them suppressible via inspections would let users silence real errors. Annotators mirror the compiler: always on, not negotiable. Naming convention warnings use `WEAK_WARNING` severity.
+
+## Trackers (Cached Utilities)
+
+`FileTracker`, `NumberTracker`, and `ScopeTracker` use `CachedValuesManager` to compute constraint sets once per PSI modification. Individual `visit()` calls check a single element against the cached set — O(1) lookup, avoiding O(n²) recomputation.
+
+**Record-Visit pattern**: Each tracker records all definitions in a scope during construction, then exposes `visit(element, holder)` methods that check one element against the recorded set.

--- a/knowledge/design/annotation-quick-fixes.md
+++ b/knowledge/design/annotation-quick-fixes.md
@@ -1,0 +1,30 @@
+---
+tags: [design, annotation, quick-fix, import]
+related: [design/annotation-layers]
+refs: [docs/design/annotation-system.md]
+---
+# Annotation Quick Fixes
+
+Annotators don't just report problems — they attach actionable repairs via `withFix()`. Annotations without fixes are complaints; annotations with fixes are workflows.
+
+## AddImportFix
+
+When `ProtobufAnnotator` encounters an unresolved type name, it creates an `ERROR` annotation with an `AddImportFix`. The fix:
+1. Searches the stub index by short name
+2. Filters candidates by qualified name suffix
+3. If one match — inserts the import directly
+4. If multiple — presents a popup
+
+Implements `HintAction` so the fix appears as an inline suggestion without requiring Alt+Enter.
+
+## RenameFix
+
+Naming convention violations attach a `RenameFix` that delegates to `RefactoringFactory.createRename()`. This ensures all references update atomically — critical because protobuf names propagate into generated code across multiple languages.
+
+## OptimizeImportsFix
+
+Unused import warnings (from `FileTracker`) attach an `OptimizeImportsFix` that removes all unused imports in one action, matching the "Optimize Imports" idiom from Java/Kotlin.
+
+## Design Principle
+
+By co-locating detection and repair, the code that best understands the problem also provides the solution — no indirection through a separate fix-registration system.

--- a/knowledge/design/compiler-in-process.md
+++ b/knowledge/design/compiler-in-process.md
@@ -1,0 +1,28 @@
+---
+tags: [design, compiler, descriptor]
+related: [design/compiler-plugin-arch, modules/grpc]
+refs: [docs/design/compiler-system.md]
+---
+# In-Process Compiler
+
+The plugin includes a pure-Kotlin compiler that walks the IntelliJ PSI tree directly and produces `FileDescriptorProto` objects — without external `protoc`.
+
+## Why?
+
+- **Zero configuration** — works immediately after installation, no PATH setup or SDK configuration
+- **PSI integration** — reads directly from already-parsed PSI tree, cached via `CachedValuesManager`, invalidated when source changes
+- **Graceful degradation** — wraps every element's compilation in try-catch, silently skipping malformed items. A syntax error in one message doesn't prevent the rest from compiling
+
+## Tradeoffs Accepted
+
+- Custom options with extension values only partially supported
+- Edition-specific semantics not fully modeled
+- Code generation is out of scope — produces metadata, not Java/Go/C++ code
+
+## Primary Consumer
+
+`ProtoFileReflection` in the gRPC module calls `Protoc.compileFiles()` to obtain descriptors, registers them with `DynamicFileSupport` from the sisyphus library, and uses them to marshal/unmarshal messages for in-IDE gRPC calls.
+
+## Import Resolution
+
+Stack-based with cycle detection: each compiled file's imports are pushed onto the stack, and already-compiled files (tracked by import path) are skipped.

--- a/knowledge/design/compiler-plugin-arch.md
+++ b/knowledge/design/compiler-plugin-arch.md
@@ -1,0 +1,29 @@
+---
+tags: [design, compiler, plugin-architecture, state-machine]
+related: [design/compiler-in-process, architecture/extension-points]
+refs: [docs/design/compiler-system.md]
+---
+# Compiler Plugin Architecture
+
+Compilation is split across 10 `ProtobufCompilerPlugin` implementations, each responsible for one element type, registered as IntelliJ extension points.
+
+## Built-in Plugins
+
+| Plugin | Compiles | Key Logic |
+|---|---|---|
+| `FileCompiler` | Files → `FileDescriptorProto` | Package, syntax, dependency extraction |
+| `MessageCompiler` | Messages → `DescriptorProto` | Recursive nesting |
+| `MessageFieldCompiler` | Fields → `FieldDescriptorProto` | Type resolution, label inference |
+| `MessageOneofCompiler` | Oneof groups | Field grouping |
+| `MessageMapEntryCompiler` | Map fields → synthetic `Entry` types | Hidden key/value messages |
+| `MessageMapFieldCompiler` | Map field wrappers | Links to synthetic entries |
+| `EnumCompiler` | Enums → `EnumDescriptorProto` | Name and value extraction |
+| `EnumValueCompiler` | Enum values | Individual constants |
+| `ServiceCompiler` | Services → `ServiceDescriptorProto` | RPC method routing |
+| `ServiceMethodCompiler` | RPC methods → `MethodDescriptorProto` | Input/output type resolution |
+
+## State Machine Model
+
+Each PSI node becomes a typed state (`ProtobufCompilingState<TDesc, TPsi>`). `CompileContext` dispatches states to plugins. States carry `target()` (mutable descriptor), `element()` (source PSI), and `parent()`.
+
+States decouple *traversal* from *transformation*: `CompileContext` handles traversal, plugins handle transformation. Typed generics prevent `MessageCompiler` from receiving an `EnumCompilingState` at compile time.

--- a/knowledge/design/completion-insert-handlers.md
+++ b/knowledge/design/completion-insert-handlers.md
@@ -1,0 +1,25 @@
+---
+tags: [design, completion, insert-handler]
+related: [design/completion-providers]
+refs: [docs/design/code-completion.md]
+---
+# Smart Insert Handlers
+
+Each lookup element carries a custom `InsertHandler` that transforms the document *beyond* just inserting text — adding closing delimiters, positioning the cursor, auto-incrementing field numbers, adding imports, and triggering follow-up completion.
+
+## Key Handler Classes
+
+- **`SmartInsertHandler`** — Core handler that inserts text at a given offset, avoids duplicating text already present (via `commonPrefixWith`), and optionally triggers follow-up completion
+- **`AddImportInsertHandler`** — Adds an import statement when completing a cross-file type
+- **`AutoPopupInsertHandler`** — Triggers `autoPopupMemberLookup` to chain completions
+- **`ComposedInsertHandler`** — Sequences multiple handlers for complex insertions
+
+## Workflow, Not Word Lookup
+
+Completing a field name isn't "insert text" — it's "insert name, assign next field number, terminate with semicolon, position cursor." Each context is a workflow.
+
+The provider-per-context model makes workflows composable and independently testable. The smart insert handler chain means each step can be mixed and matched.
+
+## AIP Extension
+
+The AIP completion system (`AipCompletionContributor`) demonstrates extensibility: it adds Google API design pattern suggestions without modifying core completion logic.

--- a/knowledge/design/completion-providers.md
+++ b/knowledge/design/completion-providers.md
@@ -1,0 +1,31 @@
+---
+tags: [design, completion, code-completion]
+related: [design/completion-insert-handlers, architecture/extension-points]
+refs: [docs/design/code-completion.md]
+---
+# Code Completion — Provider-Per-Context
+
+Protobuf completion is fundamentally context-dependent. What's valid depends on cursor position: after `message Foo {` → field types/keywords; inside a type → scalars and user types; at a field name → names derived from type.
+
+## Provider-Per-Context Model
+
+Each context gets its own `CompletionProvider` registered against a PSI pattern in `ProtobufCompletionContributor`:
+
+| Provider | Fires When | Suggests |
+|---|---|---|
+| `KeywordsProvider` | Scope-sensitive (top-level, message, enum, service) | Keywords valid at nesting depth |
+| `BuiltInTypeProvider` | Inside `ProtobufTypeName`, not after `.` | `int32`, `string`, `bool`, etc. |
+| `SyntaxProvider` | Inside `ProtobufSyntaxStatement` string | `proto2`, `proto3` |
+| `FieldNameProvider` | Field name position | Names derived from field's type |
+| `EnumValueNameProvider` | Enum value name position | `ENUM_UNSPECIFIED`, uppercase parent name |
+| `AipMethodCompletion` | Inside RPC identifier | Standard AIP method prefixes |
+| `AipResourceCompletion` | After an AIP method prefix | Full RPC signatures |
+
+## Convention-Aware Name Generation
+
+`FieldNameProvider` derives suggestions from the schema:
+- Well-known types get special treatment: `FieldMask` → `mask`, `Timestamp` → `time`
+- User types become snake_case field names via word splitting
+- `repeated` fields get pluralized names (`repeated User` → `users`)
+
+`EnumValueNameProvider` converts the parent enum name to `SCREAMING_SNAKE_CASE` and suggests `<ENUM>_UNSPECIFIED = 0;`.

--- a/knowledge/design/dual-psi-hierarchies.md
+++ b/knowledge/design/dual-psi-hierarchies.md
@@ -1,0 +1,23 @@
+---
+tags: [design, psi, prototext]
+related: [design/psi-mixin-injection, design/prototext-schema-linking]
+refs: [docs/design/psi-and-mixin.md, docs/design/prototext.md]
+---
+# Dual PSI Hierarchies
+
+Proto (`.proto`) and ProtoText (`.textproto`) have separate grammars, parsers, and PSI element hierarchies (`Protobuf*` vs `ProtoText*`). Yet both implement the *same* feature interfaces from `lang/psi/feature/`.
+
+## Why Not One Grammar?
+
+The syntaxes differ enough:
+- Different comments: proto uses `//` and `/* */`, textproto uses `#`
+- Different field syntax: proto is `int32 bar = 1;`, textproto is `bar: 42`
+- Textproto has no type definitions
+
+Merging would make the BNF harder to read and error-recovery worse.
+
+## What IS Shared
+
+The reference resolution infrastructure. TextProto references resolve *to* proto PSI classes (`ProtobufFieldDefinition`, `ProtobufEnumValueDefinition`, `ProtobufMessageDefinition`). Both use `ProtobufSymbolResolver` for scope-based lookup and the same stub indexes for cross-file resolution.
+
+The separation is at the language boundary; the integration is at the semantic boundary.

--- a/knowledge/design/editions-feature-model.md
+++ b/knowledge/design/editions-feature-model.md
@@ -1,0 +1,43 @@
+---
+tags: [design, editions, feature-set, proto2, proto3]
+related: [design/annotation-layers]
+refs: [docs/design/editions.md]
+---
+# Protobuf Editions — Feature-Set Model
+
+Editions replace `syntax = "proto2"` / `syntax = "proto3"` with `edition = "2023"`, where each behavioral difference becomes a separately toggleable feature.
+
+## ProtobufFeature Data Class
+
+```kotlin
+data class ProtobufFeature(
+    val enumType: ProtobufEnumType,                       // OPEN | CLOSED
+    val fieldPresence: ProtobufFieldPresence,             // LEGACY_REQUIRED | EXPLICIT | IMPLICIT
+    val jsonFormat: ProtobufJsonFormat,                   // ALLOW | LEGACY_BEST_EFFORT
+    val messageEncoding: ProtobufMessageEncoding,         // LENGTH_PREFIXED | DELIMITED
+    val repeatedFieldEncoding: ProtobufRepeatedFieldEncoding,  // PACKED | EXPANDED
+    val utf8Validation: ProtobufUtf8Validation,           // VERIFY | NONE
+)
+```
+
+## Backward-Compatible Defaults
+
+| Version | Enums | Presence | JSON | Repeated | UTF-8 |
+|---------|-------|----------|------|----------|-------|
+| PROTO2 | CLOSED | EXPLICIT | LEGACY_BEST_EFFORT | EXPANDED | NONE |
+| PROTO3 | OPEN | IMPLICIT | ALLOW | PACKED | VERIFY |
+| EDITION_2023 | OPEN | EXPLICIT | ALLOW | PACKED | VERIFY |
+
+EDITION_2023 is "mostly proto3, but with explicit field presence."
+
+## Implementation Status
+
+| Component | Status |
+|---|---|
+| Grammar (`EditionStatement`) | ✅ Complete |
+| PSI model (`file.edition()` API) | ✅ Complete |
+| Feature-set definitions | ✅ Complete |
+| `ProtobufEditionAnnotator` | ⚠️ Stub (exists but returns early, not registered) |
+| Feature-driven validation | ❌ Not started (still uses syntax-based annotators) |
+
+The model is defined but not yet wired into validation. Current annotators are production-tested; migration is a refactoring task. Per-element feature overrides are explicitly deferred.

--- a/knowledge/design/external-data-system.md
+++ b/knowledge/design/external-data-system.md
@@ -1,0 +1,33 @@
+---
+tags: [design, stubs, indexing, java, go, extensibility]
+related: [design/stub-system, modules/java, modules/go, modules/sisyphus]
+refs: [docs/design/stub-indexing.md]
+---
+# External Data System
+
+Each stub carries a `Map<String, String>` of external data, populated by `ProtobufStubExternalProvider` implementations at stub-creation time.
+
+## Problem
+
+Protobuf files contain language-specific options (`java_package`, `go_package`, `json_name`) that control code generation. The plugin needs this data for cross-language navigation, but it shouldn't be baked into the core stub format because:
+
+1. Not all users need all languages
+2. New languages appear (stub version bump for each would invalidate caches)
+3. Custom options are project-specific
+
+## Two-Phase Design
+
+- **`stubExternalProvider`**: Extracts option values during stub creation. Example: `FileJavaOptionsProvider` reads `java_package`, `java_outer_classname`, `java_multiple_files`.
+
+- **`indexProvider`**: Builds custom index entries from stub data during indexing. Example: `JavaIndexProvider` computes gRPC stub class names (`*ImplBase`, `*BlockingStub`, `*FutureStub`, `*CoroutineStub`).
+
+## Built-in Providers
+
+| Provider | Index | Purpose |
+|----------|-------|---------|
+| `JavaIndexProvider` | `JavaNameIndex` | Java generated class names |
+| `GoIndexProvider` | `GoNameIndex` | Go generated type names |
+| `SisyphusIndexProvider` | `SisyphusNameIndex` | Sisyphus Kotlin type names |
+| `ServiceMethodIndexProvider` | `ServiceMethodIndex` | gRPC method paths |
+
+The core stub format (`Array<String>` + `Map<String, String>`) stays stable while language-specific logic lives in optional modules.

--- a/knowledge/design/feature-interfaces.md
+++ b/knowledge/design/feature-interfaces.md
@@ -1,0 +1,25 @@
+---
+tags: [design, psi, feature-interfaces]
+related: [design/psi-mixin-injection, design/dual-psi-hierarchies]
+refs: [docs/design/psi-and-mixin.md]
+---
+# Feature Interfaces
+
+The `lang/psi/feature/` package defines cross-cutting interfaces that decouple IDE features from concrete PSI types:
+
+| Interface | Concern |
+|-----------|---------|
+| `NamedElement` | Anything with a user-visible name |
+| `ReferenceElement` | Anything that refers to another element |
+| `QualifiedElement<T>` | Dotted name chains (`a.b.c`) with root/leaf traversal |
+| `BodyOwner` / `BodyElement` | Elements with `{}`-delimited bodies |
+| `DocumentOwner` / `DocumentElement` | Doc-comment association |
+| `LookupableElement` | Completion item generation |
+| `FoldingElement` | Code folding regions |
+| `ValueElement<T>` / `ValueAssign` | Option value typing |
+
+## Why Separate Interfaces?
+
+The combinations are irregular. A `MessageDefinition` is a `BodyOwner`, `NamedElement`, and `DocumentOwner`. A `FieldDefinition` is a `NamedElement` and `OptionOwner` but not a `BodyOwner`. An `ImportStatement` is a `ReferenceElement` pointing at a file. Interfaces let the grammar declare exactly which capabilities each rule has.
+
+Without them, every IDE feature would need `instanceof` chains against concrete PSI classes. With them, implementing `NamedElement` on a new type automatically enables rename refactoring.

--- a/knowledge/design/prototext-schema-linking.md
+++ b/knowledge/design/prototext-schema-linking.md
@@ -1,0 +1,30 @@
+---
+tags: [design, prototext, schema, references]
+related: [design/prototext-separate-language, design/root-providers]
+refs: [docs/design/prototext.md]
+---
+# ProtoText Schema Linking
+
+TextProto files declare their schema using header comments:
+
+```
+# proto-file: path/to/schema.proto
+# proto-message: package.MessageName
+```
+
+## How It Works
+
+Parsed by `ProtoTextSharpCommentReferenceContributor`, creating real IntelliJ references:
+- `ProtoTextHeaderFileReference` resolves `# proto-file:` to a `ProtobufFile` (supports relative and module paths via `ProtobufRootResolver`)
+- `ProtoTextHeaderMessageReference` resolves `# proto-message:` within the resolved file's scope to a `ProtobufMessageDefinition`
+
+## Why Comments?
+
+The text format spec doesn't define a schema-linking syntax. These header comments are a de facto convention (used by Google's internal tools and `buf`). Making them comments means:
+- Files remain valid textproto regardless of tooling
+- The linking mechanism is optional — files without headers just lose IDE features
+- `ProtoTextFile.schema()` returns `null` gracefully when headers are missing
+
+## What Schema Enables
+
+The schema acts as the "type system" for textproto. Without it, field names are just strings. With it: completion, validation, navigation, and rename refactoring — all flowing from the two-line header comment.

--- a/knowledge/design/prototext-separate-language.md
+++ b/knowledge/design/prototext-separate-language.md
@@ -1,0 +1,28 @@
+---
+tags: [design, prototext, textproto, language]
+related: [design/dual-psi-hierarchies, design/prototext-schema-linking]
+refs: [docs/design/prototext.md]
+---
+# ProtoText — Separate Language
+
+ProtoText (`.textproto` / `.txtpb`) is a completely independent IntelliJ language with its own grammar (`prototext.bnf`, ~200 lines vs proto's ~600), lexer, PSI tree hierarchy, and token types.
+
+## Why Not Reuse Proto Parser?
+
+- **Grammar structure**: Proto top-level is `(Edition|Syntax)? (Import|Package|Option|Message|Enum|Service)*`. TextProto is just `Field*`.
+- **Token types**: TextProto uses `#` for comments; proto uses `//` and `/* */`.
+- **PSI semantics**: A `FieldName` in proto is a declaration site. In textproto it's a usage site that must resolve to a proto declaration. Same name, opposite roles.
+
+## Three Reference Types
+
+| Reference | Source | Resolves To |
+|---|---|---|
+| `ProtoTextFieldReference` | Field name in assignment | `ProtobufFieldLike` in the message schema |
+| `ProtoTextTypeNameReference` | Extension/any type bracket `[pkg.Type]` | Field definition or global type |
+| `ProtoTextEnumValueReference` | Enum literal value | `ProtobufEnumValueDefinition` |
+
+Field references walk up the textproto tree to find the owner message context, then search that message's items. Map field `key`/`value` handled specially.
+
+## Core Design Tension
+
+TextProto is syntactically independent but semantically dependent on proto. The architecture makes languages fully separate (different grammars, lexers, PSI trees) while making the reference system fully integrated (textproto references resolve to proto PSI nodes using shared symbol resolution).

--- a/knowledge/design/psi-mixin-injection.md
+++ b/knowledge/design/psi-mixin-injection.md
@@ -1,0 +1,34 @@
+---
+tags: [design, psi, mixin, grammar-kit]
+related: [design/feature-interfaces, design/stub-system, design/dual-psi-hierarchies]
+refs: [docs/design/psi-and-mixin.md, src/main/grammar/protobuf.bnf]
+---
+# PSI & Mixin Injection
+
+Grammar-Kit BNF files (`protobuf.bnf`, `prototext.bnf`) are the single source of truth for PSI structure. Every grammar rule can declare three orthogonal extension points:
+
+```bnf
+MessageDefinition ::= message Identifier MessageBody {
+    implements=[ "...ProtobufElement", "...BodyOwner", "...ProtobufOptionOwner" ]
+    mixin="...ProtobufMessageDefinitionMixin"
+    stubClass="...ProtobufMessageStub"
+}
+```
+
+| Attribute | Role |
+|-----------|------|
+| `implements` | Bolt on cross-cutting feature interfaces via composition |
+| `mixin` | Inject an abstract base class that provides default behavior |
+| `stubClass` | Wire up stub serialization for index-time access |
+
+## Why Not Hand-Write PSI?
+
+The grammar *will* change (new editions, custom options, AIP annotations). Changing a grammar rule auto-regenerates the PSI class; behavior stays in mixins and feature interfaces that survive regeneration.
+
+## Three-Tier Behavior Model
+
+1. **Feature interfaces** — contracts (`NamedElement`, `BodyOwner`)
+2. **Mixins** — default implementations injected at generation time
+3. **Extension functions** — domain helpers (e.g., `ProtobufTypeName.absolutely()`, `ProtobufImportStatement.public()`)
+
+Extensions are preferred when the behavior is a pure query that doesn't need to override a generated method or participate in the stub lifecycle. PSI element behavior goes in mixins, not generated classes.

--- a/knowledge/design/root-providers.md
+++ b/knowledge/design/root-providers.md
@@ -1,0 +1,28 @@
+---
+tags: [design, symbol-resolution, root-providers, imports]
+related: [design/symbol-resolution-algorithm, architecture/extension-points]
+refs: [docs/design/symbol-resolution.md]
+---
+# Root Providers
+
+The universe of resolvable proto files is project-dependent and must be pluggable.
+
+## How It Works
+
+- `ProtobufRootProvider` returns a list of `ProtobufRoot` (name + VirtualFile directory) for a given PSI context
+- `ProtobufRootResolver` collects roots from all providers, then deduplicates: providers with same `id()` collapse (first wins), roots with same `name` collapse
+- Import statements like `import "google/protobuf/timestamp.proto"` are resolved by searching the relative path against every collected root
+
+## Built-in Providers
+
+| Provider | Source |
+|----------|--------|
+| `ModuleSourceRootProvider` | Module source directories marked as proto roots |
+| `LibraryRootProvider` | JAR libraries containing `.proto` files |
+| `EmbeddedRootProvider` | Google's standard proto definitions bundled with the plugin |
+| `DecompiledRootProvider` | Proto files reconstructed from compiled descriptors |
+| `GoRootProvider` | Go module proto paths |
+
+## Caching
+
+Root computation is expensive (scanning module dependencies, JAR contents). Providers extend `CachedProtobufRootProvider` which caches results per-file using `CachedValuesManager` with a build-system-aware modification tracker.

--- a/knowledge/design/scope-hierarchy.md
+++ b/knowledge/design/scope-hierarchy.md
@@ -1,0 +1,23 @@
+---
+tags: [design, symbol-resolution, scope]
+related: [design/symbol-resolution-algorithm, design/root-providers]
+refs: [docs/design/symbol-resolution.md]
+---
+# Scope Hierarchy
+
+Scopes are modeled with two composable interfaces:
+- **`ProtobufScope`** — container with a qualified name that holds children
+- **`ProtobufScopeItem`** — anything inside a scope
+
+A `ProtobufMessageDefinition` implements *both*: it's a scope item in its parent and a scope containing its own fields/nested types. `qualifiedName()` is always `parent.scope() + name`, computed recursively.
+
+## Virtual Scopes
+
+Constructs like `oneof` and `extend` look like scopes in the grammar but *don't* create new naming scopes in protobuf — a oneof's fields belong to the enclosing message. `ProtobufVirtualScope` marks these as transparent: the `items()` helper unpacks their children directly into the parent scope's item list.
+
+This prevents oneof and extend from hiding fields during resolution while preserving the syntactic structure for formatting.
+
+## Resolution Direction
+
+- **Down**: iterate a scope's items and recurse into nested scopes when the first component matches
+- **Up** (`resolveInCurrent`): hop from scope to parent scope looking for matches

--- a/knowledge/design/stub-system.md
+++ b/knowledge/design/stub-system.md
@@ -1,0 +1,38 @@
+---
+tags: [design, stubs, indexing, performance]
+related: [design/external-data-system, design/psi-mixin-injection, architecture/extension-points]
+refs: [docs/design/stub-indexing.md]
+---
+# Stub Indexing System
+
+Stubs are lightweight serialized snapshots of PSI elements that enable fast symbol lookup without parsing every file.
+
+## What Gets Stubbed
+
+**Stubbed** (11 types): Message, Enum, EnumValue, Service, Rpc, Field, MapField, Oneof, Group, Extend, PackageName.
+
+**Not stubbed**: field types, field numbers, option values, comments, default values, method request/response types.
+
+The boundary: stubs capture *identity* (names) and *structure* (nesting). They skip *content* (types, options) because content requires cross-file resolution.
+
+## Three Core Indices
+
+| Index | Key | Optimizes |
+|-------|-----|-----------|
+| **ShortNameIndex** | Simple name (`"Timestamp"`) | Completion — fuzzy match |
+| **QualifiedNameIndex** | Full path (`"google.protobuf.Timestamp"`) | Reference resolution — exact lookup |
+| **ResourceTypeIndex** | AIP resource type | AIP compliance |
+
+All three populated in a single `indexStub()` pass.
+
+## Scope-Carrying Stubs
+
+Qualified names are computed from the stub tree, not stored verbatim. `qualifiedName()` walks the parent stub chain: file stub provides package prefix, message stubs append names. This avoids duplicating package paths hundreds of times per file.
+
+## Dual Constructors
+
+Every stub-based mixin has two constructors — AST mode (parsing) and stub mode (index loading). The same `ProtobufMessageDefinition` interface works whether backed by a parsed AST or deserialized stub.
+
+## Single Global Stub Version
+
+`getStubVersion() = 1`. Changing stub format for any element type invalidates the entire cache. The `Map<String, String>` external data absorbs most variability schema-free.

--- a/knowledge/design/symbol-resolution-algorithm.md
+++ b/knowledge/design/symbol-resolution-algorithm.md
@@ -1,0 +1,35 @@
+---
+tags: [design, symbol-resolution, imports]
+related: [design/scope-hierarchy, design/root-providers]
+refs: [docs/design/symbol-resolution.md]
+---
+# Symbol Resolution Algorithm
+
+## Absolute vs Relative
+
+A leading dot (`.google.protobuf.Timestamp`) forces absolute lookup from the root. An unqualified name (`Timestamp`, `inner.Msg`) triggers relative resolution. These are separate code paths:
+
+- **Absolute** — match the fully-qualified name against every file's package + definition tree. No scope walking.
+- **Relative** — walk up the enclosing scope chain first (`resolveInCurrent`), then compose with the file's package and search imports.
+
+## Relative Resolution Flow
+
+1. Walk up enclosing scope chain, checking each scope for a matching child
+2. If not found locally, compose the relative name with the file's package
+3. Push all imported files onto a stack and repeat relative composition for each
+4. Follow public imports transitively; regular imports are single-hop only
+
+## Import Graph Traversal
+
+- **Regular imports** — symbols available only to the importing file. Their own imports are *not* followed.
+- **Public imports** — symbols re-exported. Resolver pushes their `public` imports onto the stack for further traversal.
+- A single `if (it.public())` guard implements the full transitivity rule from the protobuf spec.
+
+## Context-Aware Filters
+
+Resolution accepts a `PsiElementFilter` that rejects invalid matches. Each reference type supplies its own filter:
+- `ProtobufTypeNameReference` — must be message or enum
+- `ProtobufFieldReference` — must be a field
+- `ProtobufExtensionFieldReference` — must belong to a specific target message
+
+This keeps the resolver generic while pushing validation to the call site.

--- a/knowledge/modules/aip.md
+++ b/knowledge/modules/aip.md
@@ -1,0 +1,29 @@
+---
+tags: [module, aip, google-api, resource]
+related: [design/completion-providers, architecture/extension-points]
+refs: [docs/modules/aip.md]
+---
+# AIP Module
+
+**Package**: `io.kanro.idea.plugin.protobuf.aip`
+**Config**: Registered in main `plugin.xml`
+
+Implements support for [Google API Improvement Proposals (AIP)](https://google.aip.dev/) — design guidelines for Google APIs covering resource types, standard methods, and field behaviors.
+
+## Features
+
+- **Annotations**: `AipAnnotator` validates resource definitions, standard method patterns (Create, Get, List, Update, Delete), and field behaviors
+- **Completion**: Resource type names, AIP method pattern suggestions, standard field names
+- **Resource References**: Resolves `(google.api.resource_reference)` type strings to target resource definitions, enabling cross-file navigation
+- **Quick Fixes**: `AddResourceImportFix` auto-imports missing resource type definitions
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `AipOptions.kt` | AIP option definitions and constants |
+| `annotator/AipAnnotator.kt` | AIP convention validation |
+| `completion/AipCompletionContributor.kt` | AIP-aware completion |
+| `method/AipSpecMethod.kt` | Standard method patterns |
+| `quickfix/AddResourceImportFix.kt` | Auto-import fix |
+| `reference/AipResourceReference.kt` | Resource reference resolution |

--- a/knowledge/modules/go.md
+++ b/knowledge/modules/go.md
@@ -1,0 +1,27 @@
+---
+tags: [module, go, decompilation, navigation]
+related: [design/external-data-system, architecture/extension-points]
+refs: [docs/modules/go.md]
+---
+# Go Integration Module
+
+**Package**: `io.kanro.idea.plugin.protobuf.golang`
+**Config**: `META-INF/io.kanro.idea.plugin.protobuf-go.xml`
+**Dependency**: `org.jetbrains.plugins.go` (optional)
+
+## Features
+
+- **Line Markers**: Bidirectional gutter icons between `.proto` definitions and generated `.pb.go` files
+- **Decompilation**: Reconstructs original `.proto` definitions from compiled proto descriptors embedded in `.pb.go` files. Useful for navigating dependencies that only ship compiled descriptors
+- **Import Root**: `GoRootProvider` adds Go module proto paths to the import resolution chain
+- **Index**: `GoIndexProvider` indexes proto elements with their Go type names using protobuf-Go naming conventions
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `GoRootProvider.kt` | Import root from Go modules |
+| `GoIndexProvider.kt` | Stub index contributions |
+| `GoDecompileService.kt` | Proto decompilation from Go |
+| `GoLineMarkerProvider.kt` | Go-side gutter icons |
+| `Names.kt` | Go naming conventions |

--- a/knowledge/modules/grpc.md
+++ b/knowledge/modules/grpc.md
@@ -1,0 +1,27 @@
+---
+tags: [module, grpc, http-client, microservices]
+related: [design/compiler-in-process, modules/java]
+refs: [docs/modules/grpc.md]
+---
+# gRPC Support Module
+
+**Package**: `io.kanro.idea.plugin.protobuf.grpc`
+**Config**: `META-INF/io.kanro.idea.plugin.protobuf-client.xml`, `META-INF/io.kanro.idea.plugin.protobuf-microservices.xml`
+**Dependencies**: `com.jetbrains.restClient` (optional), `com.intellij.modules.microservices` (optional)
+
+## Features
+
+- **Request Execution**: Execute gRPC requests via IntelliJ's HTTP Client — native gRPC (HTTP/2), gRPC-Web, and HTTP Transcoding (RESTful JSON)
+- **Gutter Icons**: One-click request execution from `rpc` definitions, generates pre-configured HTTP Client request files
+- **Endpoint Discovery**: Exposes gRPC services in IntelliJ's Endpoints/Microservices view
+- **Request Editor**: JSON field completion for gRPC request bodies using proto message schema
+
+## Subpackages
+
+| Package | Purpose |
+|---------|---------|
+| `grpc/request/` | Request execution, MIME types, content handling |
+| `grpc/gutter/` | Gutter icon providers |
+| `grpc/index/` | Service method indices (`ServiceMethodIndex`) |
+| `grpc/editor/` | JSON field completion in request bodies |
+| `microservices/` | Endpoints view integration |

--- a/knowledge/modules/java.md
+++ b/knowledge/modules/java.md
@@ -1,0 +1,34 @@
+---
+tags: [module, java, navigation, find-usages]
+related: [design/external-data-system, architecture/extension-points]
+refs: [docs/modules/java.md]
+---
+# Java Integration Module
+
+**Package**: `io.kanro.idea.plugin.protobuf.java`
+**Config**: `META-INF/io.kanro.idea.plugin.protobuf-java.xml`
+**Dependency**: `com.intellij.modules.java` (optional)
+
+## Features
+
+- **Line Markers**: Bidirectional gutter icons between `.proto` definitions and generated Java classes
+- **Find Usages**: Java code using generated proto classes appears in "Find Usages" for the proto definition
+- **Index**: `JavaIndexProvider` indexes with Java class names computed from `java_package`, `java_outer_classname`, `java_multiple_files`
+- **Stub External Data**: `FileJavaOptionsProvider` extracts Java options at stub-creation time
+
+## Java Name Resolution (`Names.kt`)
+
+- Package: `java_package` option → proto package fallback
+- Outer class: `java_outer_classname` option → derived from filename
+- Multiple files: when `java_multiple_files = true`, top-level messages get their own classes
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `JavaIndexProvider.kt` | Stub index contributions |
+| `JavaLineMarkerProvider.kt` | Java-side gutter icons |
+| `ProtobufLineMarkerProvider.kt` | Proto-side gutter icons |
+| `JavaFindUsageFactory.kt` | Find usage integration |
+| `FileJavaOptionsProvider.kt` | Java option stub data |
+| `Names.kt` | Java naming rules |

--- a/knowledge/modules/sisyphus.md
+++ b/knowledge/modules/sisyphus.md
@@ -1,0 +1,29 @@
+---
+tags: [module, sisyphus, kotlin, framework]
+related: [design/external-data-system, modules/java]
+refs: [docs/modules/sisyphus.md]
+---
+# Sisyphus Integration Module
+
+**Package**: `io.kanro.idea.plugin.protobuf.sisyphus`
+**Config**: `META-INF/io.kanro.idea.plugin.protobuf-sisyphus.xml`
+**Dependency**: `org.jetbrains.kotlin` (optional)
+
+Integrates with the [Sisyphus](https://github.com/nicecraftz/sisyphus) Kotlin/gRPC framework, which generates Kotlin DSL APIs from proto definitions.
+
+## Features
+
+- **Line Markers**: Bidirectional gutter icons between proto definitions and Sisyphus-generated Kotlin classes
+- **Find Usages**: Kotlin code using Sisyphus-generated types appears in "Find Usages" for proto definitions
+- **Index**: `SisyphusIndexProvider` indexes proto elements with their Sisyphus Kotlin class names
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `SisyphusIndexProvider.kt` | Stub index contributions |
+| `SisyphusNameIndex.kt` | Name index |
+| `SisyphusKotlinLineMarkerProvider.kt` | Kotlin-side gutter icons |
+| `SisyphusProtobufLineMarkerProvider.kt` | Proto-side gutter icons |
+| `SisyphusFindUsageFactory.kt` | Find usage integration |
+| `Names.kt` | Sisyphus naming conventions |

--- a/knowledge/workflow/building-and-testing.md
+++ b/knowledge/workflow/building-and-testing.md
@@ -1,0 +1,52 @@
+---
+tags: [workflow, build, test, setup]
+related: [workflow/contributing-guide]
+refs: [docs/getting-started.md]
+---
+# Building and Testing
+
+## Prerequisites
+
+- **JDK 21** — Required for building and running
+- **IntelliJ IDEA** — Ultimate Edition recommended
+- **Gradle 8.10.2** — Bundled via wrapper (`gradlew`)
+
+## Commands
+
+```bash
+./gradlew build    # Generate parser/lexer, compile, test, build artifact
+./gradlew runIde   # Run plugin in sandboxed IDE instance
+./gradlew test     # Run tests only
+```
+
+## Project Structure
+
+```
+├── build.gradle.kts          # Build configuration & dependencies
+├── gradle.properties          # Plugin version, platform version
+├── src/
+│   ├── main/
+│   │   ├── grammar/           # BNF & FLEX grammar files
+│   │   ├── java/              # Java sources (parser util)
+│   │   ├── kotlin/            # Kotlin sources (main codebase)
+│   │   └── resources/         # Plugin descriptors, icons, built-in protos
+│   └── test/                  # Test sources
+├── resources/                 # Marketing assets (screenshots, logo)
+└── docs/                      # Documentation
+```
+
+## Grammar Development
+
+| File | Tool | Output |
+|------|------|--------|
+| `protobuf.bnf` | Grammar-Kit | Parser + PSI classes |
+| `protobuf.flex` | JFlex | Lexer |
+| `prototext.bnf` | Grammar-Kit | Proto text parser + PSI |
+| `prototext.flex` | JFlex | Proto text lexer |
+
+Generated code goes to `build/generated/sources/grammar/`. Never edit generated files — modify grammar definitions instead.
+
+## CI/CD
+
+- **Build workflow** (`.github/workflows/build.yml`) — Runs on push to `main` and all PRs
+- **Release workflow** (`.github/workflows/release.yml`) — Triggered by GitHub Releases, publishes to JetBrains Marketplace

--- a/knowledge/workflow/contributing-guide.md
+++ b/knowledge/workflow/contributing-guide.md
@@ -1,0 +1,32 @@
+---
+tags: [workflow, contributing, code-style]
+related: [workflow/building-and-testing, design/psi-mixin-injection]
+refs: [docs/contributing.md]
+---
+# Contributing Guide
+
+## Code Style
+
+- Kotlin is the primary language (99%+ of source)
+- Follow existing patterns in the codebase
+- PSI element behavior goes in mixins, not generated classes
+- Use extension functions for utility code
+
+## Adding a New Language Feature
+
+1. **Annotator/Inspection**: Add to `lang/annotator/`, register in `plugin.xml`
+2. **Completion**: Add provider in `lang/completion/`, register in `ProtobufCompletionContributor`
+3. **Quick fix**: Add to `lang/quickfix/`, register via annotator or inspection
+4. **Reference**: Add provider in `lang/reference/`, register in `ProtobufSymbolReferenceContributor`
+
+## Adding a New Integration Module
+
+1. Create package under `src/main/kotlin/.../protobuf/<module>/`
+2. Create XML config at `src/main/resources/META-INF/io.kanro.idea.plugin.protobuf-<module>.xml`
+3. Add optional dependency in main `plugin.xml`
+4. Implement required providers (index, line marker, find usage)
+5. Add documentation in `docs/modules/<module>.md`
+
+## Copilot Workflow
+
+This project uses AI-assisted development following: `brainstorm → implement → ship → reflect`. Design discussions happen in `.github/brainstorm.md`, commits go through build verification, and post-ship reflections are captured in `.github/knowledge.md`.


### PR DESCRIPTION
## Summary
- update IntelliJ Platform Gradle Plugin to 2.16.0 and Grammar-Kit to 2023.3.0.3
- upgrade Gradle wrapper to 9.0.0 for plugin compatibility
- adapt the IntelliJ Platform dependency declaration to the latest API
- restore README plugin description markers required by patchPluginXml

## Validation
- Build succeeded in a clean temporary workspace with JDK 21: `gradlew.bat build --project-cache-dir <temp> --no-configuration-cache`.
- Standard workspace build is blocked locally by a Gradle cache file-lock/directory permission issue under `.gradle`.