### PR TITLE
Fix verifyPlugin task

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@
 
 <!-- Plugin description -->
 
-## ✨ What It Does
+## What It Does
 
 This plugin turns your JetBrains IDE into a protobuf-aware development environment — not just syntax highlighting, but deep understanding of your schema.
 

--- a/settings.gradle.kts
+++ b/settings.gradle.kts
@@ -1,5 +1,5 @@
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version "0.8.0"
+    id("org.gradle.toolchains.foojay-resolver-convention") version "1.0.0"
 }
 
 rootProject.name = "idea-protobuf-plugin"


### PR DESCRIPTION
## Summary

**Title:** Fix `verifyPlugin` task failing on plugin description validation

**Description:**

The `verifyPlugin` Gradle task was failing with:
```
Invalid plugin descriptor 'description'. The plugin description must start with Latin characters and have at least 40 characters.
```

Despite the message, the actual cause was the `✨` emoji in the `## ✨ What It Does` heading inside the `<!-- Plugin description -->` block in `README.md`. IntelliJ Plugin Verifier validates the description's plain text against the regex `^[\w\s\p{Punct}\u2013\u2014]{40,}` (ASCII word/whitespace/punctuation characters plus en/em dashes) for its first 40+ characters — any emoji in that range breaks the match, even though the error text suggests a "must start with Latin characters" issue.

**Changes:**
- Removed the `✨` emoji from the `## What It Does` heading in the plugin description section of `README.md`.
- Bumped the `foojay-resolver-convention` plugin version from `0.8.0` to `1.0.0` in `settings.gradle.kts`.

**Test plan:**
- [x] `./gradlew clean verifyPlugin` completes with `BUILD SUCCESSFUL`